### PR TITLE
feat: protect admin routes with auth guard

### DIFF
--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -103,7 +103,11 @@ async function handleSubmit() {
     }
 
     // Successful login - redirect to intended page or admin
-    const redirectTo = route.query.redirect as string || '/admin'
+    // Validate redirect path to prevent open redirect vulnerabilities
+    const redirectPath = route.query.redirect
+    const redirectTo = (typeof redirectPath === 'string' && redirectPath.startsWith('/'))
+      ? redirectPath
+      : '/admin'
     router.push(redirectTo)
   } catch (err) {
     errorMessage.value = 'An unexpected error occurred. Please try again.'


### PR DESCRIPTION
## Summary
- Router guard checks Supabase session before accessing protected routes
- Unauthenticated users are redirected to `/login?redirect=/admin`
- LoginView uses redirect query param to return to intended page after login

Closes #32

## Test plan
- [ ] Navigate to `/admin` when not logged in - redirected to `/login?redirect=/admin`
- [ ] Log in successfully - redirected to `/admin`
- [ ] Navigate to `/admin` when logged in - access granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)