### PR TITLE
fix: correct watchtower image tag

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,7 +49,7 @@ services:
     # Using nicholas-fedor's maintained fork - containrrr/watchtower was archived Dec 2025
     # and is incompatible with Docker 29+ (requires API v1.44+)
     # See: https://github.com/containrrr/watchtower/issues/2122
-    image: nickfedor/watchtower:1.13.1
+    image: nickfedor/watchtower:1.13.1@sha256:fee923fe9ae4e226539de0f6036b28d8ae8bdc7df3525217a2e6513cd4964643
     container_name: watchtower
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
GHCR tag format was wrong. Use Docker Hub: `nickfedor/watchtower:1.13.1`