### PR TITLE
fix: copy pnpm-lock.yaml for frontend Docker build

### DIFF
--- a/.github/workflows/build-and-push-frontend.yml
+++ b/.github/workflows/build-and-push-frontend.yml
@@ -28,6 +28,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Copy lockfile to app directory
+        run: cp pnpm-lock.yaml app/
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
## Summary
- Fixes frontend Docker build failure
- Copies pnpm-lock.yaml from monorepo root to app/ before building

The build was failing because the Dockerfile expects the lockfile in the app directory.

## Test plan
- [ ] Merge and verify the GitHub Action succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)