### PR TITLE
fix: use monorepo root context for frontend Docker build

### DIFF
--- a/.github/workflows/build-and-push-frontend.yml
+++ b/.github/workflows/build-and-push-frontend.yml
@@ -28,13 +28,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Copy lockfile to app directory
-        run: cp pnpm-lock.yaml app/
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: ./app
+          context: .
+          file: ./app/Dockerfile
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/frontend:latest

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,20 +1,21 @@
 # Multi-stage Dockerfile for production frontend deployment
+# Build context must be the monorepo root (not ./app)
+
 # Stage 1: Builder - install dependencies and build
 FROM node:20-alpine AS builder
 
-# Enable corepack for pnpm
 RUN corepack enable
-
 WORKDIR /app
 
-# Copy dependency manifests
-COPY package.json pnpm-lock.yaml ./
+# Copy workspace config first (for layer caching)
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY app/package.json ./app/
 
-# Install dependencies with frozen lockfile for reproducibility
-RUN pnpm install --frozen-lockfile
+# Install dependencies with cache mount
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
-# Copy application source (uses .dockerignore to exclude node_modules, dist, .env*)
-COPY . .
+# Copy app source
+COPY app ./app
 
 # Build-time environment variables for Vite
 ARG VITE_API_URL
@@ -28,6 +29,7 @@ ENV VITE_WEBAUTHN_RP_NAME=$VITE_WEBAUTHN_RP_NAME
 ENV VITE_WEBAUTHN_RP_ID=$VITE_WEBAUTHN_RP_ID
 
 # Build the application
+WORKDIR /app/app
 RUN pnpm build
 
 # Stage 2: Runtime - minimal production image with nginx
@@ -37,10 +39,10 @@ FROM nginx:alpine
 RUN apk add --no-cache wget
 
 # Copy built files from builder
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/app/dist /usr/share/nginx/html
 
-# Copy nginx configuration (will be created in next commit)
-COPY nginx.conf /etc/nginx/nginx.conf
+# Copy nginx configuration
+COPY app/nginx.conf /etc/nginx/nginx.conf
 
 # Expose HTTP port
 EXPOSE 80


### PR DESCRIPTION
## Summary
- Fixes frontend Docker build by using monorepo root as build context
- Follows [official pnpm Docker best practices](https://pnpm.io/docker)

## Changes
- **Dockerfile**: Now expects root context, copies workspace files properly
- **Workflow**: Uses `context: .` with `file: ./app/Dockerfile`
- Removed workaround lockfile copy step

## Why
pnpm monorepos have a single lockfile at root that references the workspace structure. Building from `./app` context alone doesn't work because the lockfile doesn't match the isolated package.json.

## Test plan
- [ ] Merge and verify GitHub Action succeeds
- [ ] Pull image on server and verify health endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)