### PR TITLE
fix: include pnpm workspace files in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,6 @@
 .git
 .gitignore
 node_modules
-pnpm-lock.yaml
-pnpm-workspace.yaml
 
 # App/API build outputs
 **/dist


### PR DESCRIPTION
## Summary
- Removes `pnpm-lock.yaml` and `pnpm-workspace.yaml` from `.dockerignore`
- These files are required for the frontend Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)