### PR TITLE
fix(app): pass inviteCode to registration endpoint

### DIFF
--- a/app/src/views/RegisterView.vue
+++ b/app/src/views/RegisterView.vue
@@ -162,7 +162,10 @@ const onSubmit = handleSubmit(async values => {
 
   try {
     // Extract invite code from URL query params (if present)
-    const inviteCode = route.query.invite as string | undefined
+    // Handle case where query param appears multiple times (string[])
+    const inviteCode = Array.isArray(route.query.invite)
+      ? route.query.invite[0]
+      : route.query.invite
 
     // Step 1: Get registration options from backend
     const { options } = await api.post<{ options: PublicKeyCredentialCreationOptionsJSON }>(

--- a/app/src/views/__tests__/RegisterView.test.ts
+++ b/app/src/views/__tests__/RegisterView.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import RegisterView from '../RegisterView.vue'
 
@@ -58,6 +58,7 @@ import { api } from '@/lib/api'
 
 describe('RegisterView - Invite Flow', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
     vi.resetAllMocks()
 
@@ -68,6 +69,10 @@ describe('RegisterView - Invite Flow', () => {
         json: () => Promise.resolve({ registrationOpen: true })
       } as Response)
     )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('should pass inviteCode to register/options when present in URL', async () => {
@@ -88,9 +93,10 @@ describe('RegisterView - Invite Flow', () => {
       }
     })
 
-    // Wait for onMounted to complete
+    // Wait for onMounted async operations to complete
+    await vi.runAllTimersAsync()
+    await flushPromises()
     await nextTick()
-    await new Promise(resolve => setTimeout(resolve, 50))
 
     // Fill form
     await wrapper.find('input[type="email"]').setValue('test@example.com')
@@ -115,9 +121,11 @@ describe('RegisterView - Invite Flow', () => {
 
     // Submit form
     await wrapper.find('form').trigger('submit.prevent')
-    await nextTick()
+
     // Wait for form validation and async submission
-    await new Promise(resolve => setTimeout(resolve, 100))
+    await vi.runAllTimersAsync()
+    await flushPromises()
+    await nextTick()
 
     // Verify inviteCode was passed to register/options
     expect(api.post).toHaveBeenCalledWith(
@@ -147,9 +155,10 @@ describe('RegisterView - Invite Flow', () => {
       }
     })
 
-    // Wait for onMounted to complete
+    // Wait for onMounted async operations to complete
+    await vi.runAllTimersAsync()
+    await flushPromises()
     await nextTick()
-    await new Promise(resolve => setTimeout(resolve, 50))
 
     // Fill form
     await wrapper.find('input[type="email"]').setValue('first@example.com')
@@ -174,9 +183,11 @@ describe('RegisterView - Invite Flow', () => {
 
     // Submit form
     await wrapper.find('form').trigger('submit.prevent')
-    await nextTick()
+
     // Wait for form validation and async submission
-    await new Promise(resolve => setTimeout(resolve, 100))
+    await vi.runAllTimersAsync()
+    await flushPromises()
+    await nextTick()
 
     // Verify request works without inviteCode
     expect(api.post).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- **Fix:** Pass `inviteCode` from URL query params to `/api/auth/register/options` endpoint
- **Root cause:** Frontend wasn't sending the invite code, so backend couldn't grant trip access
- **Tests:** Added RegisterView integration tests to prevent regression

## Changes

### Commit 1: `fix(app): pass inviteCode to register/options endpoint`
Extract invite code from `route.query.invite` and include it in the registration API request.

### Commit 2: `test(app/views): add integration test for invite registration flow`
Added Vitest tests verifying:
- inviteCode is passed when present in URL
- Registration works without inviteCode (first-user scenario)

## Test plan

- [x] Unit tests pass (21/21)
- [x] Type check passes
- [ ] Manual test: First-user registration (no invite) still works
- [ ] Manual test: Invite registration grants trip access immediately
- [ ] Manual test: Invalid/expired invites are rejected

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)