### PR TITLE
feat(api): Section CRUD endpoints

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,6 +7,7 @@ import { trips } from "./routes/trips";
 import { upload } from "./routes/upload";
 import { invites } from "./routes/invites";
 import { tripAccess } from "./routes/trip-access";
+import { sections } from "./routes/sections";
 import { connectWithRetry } from "./db/client";
 
 const app = new Hono();
@@ -21,6 +22,7 @@ app.route("/api/auth", auth);
 app.route("/api/trips", trips);
 app.route("/api/invites", invites);
 app.route("/api", tripAccess);
+app.route("/api", sections);
 app.route("/api", upload);
 
 // Root

--- a/api/src/routes/sections.test.ts
+++ b/api/src/routes/sections.test.ts
@@ -1,0 +1,736 @@
+// Environment loaded automatically from .env.test via bunfig.toml preload
+
+import { describe, expect, it, mock, afterEach } from "bun:test";
+import { Hono } from "hono";
+import { sections } from "./sections";
+import type { AuthEnv } from "../types/auth";
+import { getDbClient } from "../db/client";
+import { getAdminAuthHeader, getUserAuthHeader } from "../test-helpers";
+import { createTrip, createPhoto, cleanupTrip } from "../test-factories";
+import type { ErrorResponse, SectionResponse } from "../test-types";
+
+// Mock R2 to ensure tests use local filesystem fallback
+mock.module("../utils/r2", () => ({
+  uploadToR2: async () => false,
+  getFromR2: async () => null,
+  isR2Available: () => false,
+  deleteMultipleFromR2: async () => 0,
+  PHOTOS_URL_PREFIX: "/api/photos/",
+}));
+
+// Create test app
+function createTestApp() {
+  const app = new Hono<AuthEnv>();
+  app.route("/api", sections); // Mount at /api (same as main app)
+  return app;
+}
+
+// Helper for creating sections via API
+async function createSection(
+  app: Hono<AuthEnv>,
+  tripId: string,
+  title: string,
+  orderIndex: number,
+): Promise<SectionResponse> {
+  const headers = await getAdminAuthHeader();
+  const res = await app.fetch(
+    new Request(`http://localhost/api/trips/${tripId}/sections`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ title, orderIndex }),
+    }),
+  );
+  return res.json() as Promise<SectionResponse>;
+}
+
+describe("Section Routes", () => {
+  // =============================================================================
+  // GET /api/trips/:tripId/sections - List sections for a trip
+  // =============================================================================
+  describe("GET /api/trips/:tripId/sections", () => {
+    const createdTripIds: string[] = [];
+
+    afterEach(async () => {
+      for (const id of createdTripIds) await cleanupTrip(id);
+      createdTripIds.length = 0;
+    });
+
+    it("returns empty array for trip with no sections", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Empty Trip" });
+      createdTripIds.push(trip.id);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { sections: SectionResponse[] };
+      expect(Array.isArray(data.sections)).toBe(true);
+      expect(data.sections.length).toBe(0);
+    });
+
+    it("returns sections ordered by order_index", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Ordered Trip" });
+      createdTripIds.push(trip.id);
+
+      // Create sections out of order
+      await createSection(app, trip.id, "Third", 2);
+      await createSection(app, trip.id, "First", 0);
+      await createSection(app, trip.id, "Second", 1);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { sections: SectionResponse[] };
+      expect(data.sections.length).toBe(3);
+      expect(data.sections[0].title).toBe("First");
+      expect(data.sections[1].title).toBe("Second");
+      expect(data.sections[2].title).toBe("Third");
+    });
+
+    it("returns 404 for non-existent trip", async () => {
+      const app = createTestApp();
+      const headers = await getAdminAuthHeader();
+
+      const fakeUuid = "00000000-0000-0000-0000-000000000000";
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${fakeUuid}/sections`, {
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(404);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Not Found");
+    });
+
+    it("returns 400 for invalid tripId UUID", async () => {
+      const app = createTestApp();
+      const headers = await getAdminAuthHeader();
+
+      const res = await app.fetch(
+        new Request("http://localhost/api/trips/not-a-uuid/sections", {
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("Invalid trip ID format");
+    });
+
+    it("requires admin auth (401 without token)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Auth Test" });
+      createdTripIds.push(trip.id);
+
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`),
+      );
+
+      expect(res.status).toBe(401);
+    });
+
+    it("requires admin auth (403 for non-admin user)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Auth Test" });
+      createdTripIds.push(trip.id);
+
+      const headers = await getUserAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // =============================================================================
+  // POST /api/trips/:tripId/sections - Create a section
+  // =============================================================================
+  describe("POST /api/trips/:tripId/sections", () => {
+    const createdTripIds: string[] = [];
+
+    afterEach(async () => {
+      for (const id of createdTripIds) await cleanupTrip(id);
+      createdTripIds.length = 0;
+    });
+
+    it("creates section successfully", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Create Test" });
+      createdTripIds.push(trip.id);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "First Section", orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(201);
+      const data = (await res.json()) as SectionResponse;
+      expect(data.title).toBe("First Section");
+      expect(data.orderIndex).toBe(0);
+      expect(data.tripId).toBe(trip.id);
+      expect(data.id).toBeDefined();
+    });
+
+    it("returns 400 for empty title", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Empty Title Test" });
+      createdTripIds.push(trip.id);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "   ", orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("Title is required");
+    });
+
+    it("returns 400 for title > 200 chars", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Long Title Test" });
+      createdTripIds.push(trip.id);
+
+      const longTitle = "a".repeat(201);
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: longTitle, orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("200 characters");
+    });
+
+    it("returns 400 for negative orderIndex", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Negative Index Test" });
+      createdTripIds.push(trip.id);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", orderIndex: -1 }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("non-negative");
+    });
+
+    it("returns 409 for duplicate (trip_id, order_index)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Duplicate Order Test" });
+      createdTripIds.push(trip.id);
+
+      // Create first section with orderIndex 0
+      await createSection(app, trip.id, "First", 0);
+
+      // Try to create another section with same orderIndex
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Second", orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(409);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Conflict");
+      expect(data.message).toContain("order already exists");
+    });
+
+    it("returns 404 for non-existent trip", async () => {
+      const app = createTestApp();
+      const headers = await getAdminAuthHeader();
+
+      const fakeUuid = "00000000-0000-0000-0000-000000000000";
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${fakeUuid}/sections`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(404);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Not Found");
+    });
+
+    it("returns 400 for invalid tripId UUID", async () => {
+      const app = createTestApp();
+      const headers = await getAdminAuthHeader();
+
+      const res = await app.fetch(
+        new Request("http://localhost/api/trips/not-a-uuid/sections", {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("Invalid trip ID format");
+    });
+
+    it("requires admin auth (401 without token)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Auth Test" });
+      createdTripIds.push(trip.id);
+
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(401);
+    });
+
+    it("requires admin auth (403 for non-admin user)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Auth Test" });
+      createdTripIds.push(trip.id);
+
+      const headers = await getUserAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // =============================================================================
+  // PATCH /api/sections/:id - Update a section
+  // =============================================================================
+  describe("PATCH /api/sections/:id", () => {
+    const createdTripIds: string[] = [];
+
+    afterEach(async () => {
+      for (const id of createdTripIds) await cleanupTrip(id);
+      createdTripIds.length = 0;
+    });
+
+    it("updates title successfully", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Update Title Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Original Title", 0);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Updated Title" }),
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as SectionResponse;
+      expect(data.title).toBe("Updated Title");
+      expect(data.orderIndex).toBe(0); // Unchanged
+    });
+
+    it("updates orderIndex successfully", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Update Order Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Section", 0);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ orderIndex: 5 }),
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as SectionResponse;
+      expect(data.orderIndex).toBe(5);
+      expect(data.title).toBe("Section"); // Unchanged
+    });
+
+    it("updates both fields successfully", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Update Both Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Original", 0);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Updated", orderIndex: 3 }),
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as SectionResponse;
+      expect(data.title).toBe("Updated");
+      expect(data.orderIndex).toBe(3);
+    });
+
+    it("returns 400 for no fields provided", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "No Fields Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Section", 0);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("At least one field");
+    });
+
+    it("returns 400 for empty title", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Empty Title Update Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Original", 0);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "   " }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("Title is required");
+    });
+
+    it("returns 400 for negative orderIndex", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Negative Update Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Section", 0);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ orderIndex: -1 }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("non-negative");
+    });
+
+    it("returns 409 for duplicate orderIndex in same trip", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Duplicate Update Test" });
+      createdTripIds.push(trip.id);
+
+      // Create section1 with orderIndex 0 (creates the conflict target)
+      await createSection(app, trip.id, "First", 0);
+      const section2 = await createSection(app, trip.id, "Second", 1);
+
+      // Try to update section2 to have same orderIndex as section1
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section2.id}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ orderIndex: 0 }),
+        }),
+      );
+
+      expect(res.status).toBe(409);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Conflict");
+      expect(data.message).toContain("order already exists");
+    });
+
+    it("returns 404 for non-existent section", async () => {
+      const app = createTestApp();
+      const headers = await getAdminAuthHeader();
+
+      const fakeUuid = "00000000-0000-0000-0000-000000000000";
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${fakeUuid}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Updated" }),
+        }),
+      );
+
+      expect(res.status).toBe(404);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Not Found");
+    });
+
+    it("returns 400 for invalid section id UUID", async () => {
+      const app = createTestApp();
+      const headers = await getAdminAuthHeader();
+
+      const res = await app.fetch(
+        new Request("http://localhost/api/not-a-uuid", {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Updated" }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("Invalid section ID format");
+    });
+
+    it("requires admin auth (401 without token)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Auth Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Section", 0);
+
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Updated" }),
+        }),
+      );
+
+      expect(res.status).toBe(401);
+    });
+
+    it("requires admin auth (403 for non-admin user)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Auth Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Section", 0);
+
+      const headers = await getUserAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "PATCH",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Updated" }),
+        }),
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // =============================================================================
+  // DELETE /api/sections/:id - Delete a section
+  // =============================================================================
+  describe("DELETE /api/sections/:id", () => {
+    const createdTripIds: string[] = [];
+
+    afterEach(async () => {
+      for (const id of createdTripIds) await cleanupTrip(id);
+      createdTripIds.length = 0;
+    });
+
+    it("deletes section successfully (204)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Delete Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "To Delete", 0);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "DELETE",
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(204);
+      expect(await res.text()).toBe("");
+
+      // Verify section is deleted
+      const listRes = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          headers,
+        }),
+      );
+      const data = (await listRes.json()) as { sections: SectionResponse[] };
+      expect(data.sections.length).toBe(0);
+    });
+
+    it("sets photos.section_id to NULL (verify cascade)", async () => {
+      const app = createTestApp();
+      const db = getDbClient();
+      const trip = await createTrip({ title: "Cascade Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "With Photo", 0);
+
+      // Create photo and assign to section
+      const photo = await createPhoto({ tripId: trip.id });
+      await db`
+        UPDATE photos SET section_id = ${section.id} WHERE id = ${photo.id}
+      `;
+
+      // Verify photo has section_id
+      const [photoBeforeDelete] = await db<{ section_id: string | null }[]>`
+        SELECT section_id FROM photos WHERE id = ${photo.id}
+      `;
+      expect(photoBeforeDelete.section_id).toBe(section.id);
+
+      // Delete section
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "DELETE",
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(204);
+
+      // Verify photo.section_id is NULL
+      const [photoAfterDelete] = await db<{ section_id: string | null }[]>`
+        SELECT section_id FROM photos WHERE id = ${photo.id}
+      `;
+      expect(photoAfterDelete.section_id).toBeNull();
+    });
+
+    it("returns 404 for non-existent section", async () => {
+      const app = createTestApp();
+      const headers = await getAdminAuthHeader();
+
+      const fakeUuid = "00000000-0000-0000-0000-000000000000";
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${fakeUuid}`, {
+          method: "DELETE",
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(404);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Not Found");
+    });
+
+    it("returns 400 for invalid section id UUID", async () => {
+      const app = createTestApp();
+      const headers = await getAdminAuthHeader();
+
+      const res = await app.fetch(
+        new Request("http://localhost/api/not-a-uuid", {
+          method: "DELETE",
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("Invalid section ID format");
+    });
+
+    it("requires admin auth (401 without token)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Auth Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Section", 0);
+
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "DELETE",
+        }),
+      );
+
+      expect(res.status).toBe(401);
+    });
+
+    it("requires admin auth (403 for non-admin user)", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Auth Test" });
+      createdTripIds.push(trip.id);
+
+      const section = await createSection(app, trip.id, "Section", 0);
+
+      const headers = await getUserAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/${section.id}`, {
+          method: "DELETE",
+          headers,
+        }),
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/api/src/routes/sections.test.ts
+++ b/api/src/routes/sections.test.ts
@@ -386,7 +386,7 @@ describe("Section Routes", () => {
 
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ title: "Updated Title" }),
@@ -408,7 +408,7 @@ describe("Section Routes", () => {
 
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ orderIndex: 5 }),
@@ -430,7 +430,7 @@ describe("Section Routes", () => {
 
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ title: "Updated", orderIndex: 3 }),
@@ -452,7 +452,7 @@ describe("Section Routes", () => {
 
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({}),
@@ -474,7 +474,7 @@ describe("Section Routes", () => {
 
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ title: "   " }),
@@ -496,7 +496,7 @@ describe("Section Routes", () => {
 
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ orderIndex: -1 }),
@@ -521,7 +521,7 @@ describe("Section Routes", () => {
       // Try to update section2 to have same orderIndex as section1
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section2.id}`, {
+        new Request(`http://localhost/api/sections/${section2.id}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ orderIndex: 0 }),
@@ -540,7 +540,7 @@ describe("Section Routes", () => {
 
       const fakeUuid = "00000000-0000-0000-0000-000000000000";
       const res = await app.fetch(
-        new Request(`http://localhost/api/${fakeUuid}`, {
+        new Request(`http://localhost/api/sections/${fakeUuid}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ title: "Updated" }),
@@ -557,7 +557,7 @@ describe("Section Routes", () => {
       const headers = await getAdminAuthHeader();
 
       const res = await app.fetch(
-        new Request("http://localhost/api/not-a-uuid", {
+        new Request("http://localhost/api/sections/not-a-uuid", {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ title: "Updated" }),
@@ -578,7 +578,7 @@ describe("Section Routes", () => {
       const section = await createSection(app, trip.id, "Section", 0);
 
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ title: "Updated" }),
@@ -597,7 +597,7 @@ describe("Section Routes", () => {
 
       const headers = await getUserAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "PATCH",
           headers: { ...headers, "Content-Type": "application/json" },
           body: JSON.stringify({ title: "Updated" }),
@@ -628,7 +628,7 @@ describe("Section Routes", () => {
 
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "DELETE",
           headers,
         }),
@@ -670,7 +670,7 @@ describe("Section Routes", () => {
       // Delete section
       const headers = await getAdminAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "DELETE",
           headers,
         }),
@@ -691,7 +691,7 @@ describe("Section Routes", () => {
 
       const fakeUuid = "00000000-0000-0000-0000-000000000000";
       const res = await app.fetch(
-        new Request(`http://localhost/api/${fakeUuid}`, {
+        new Request(`http://localhost/api/sections/${fakeUuid}`, {
           method: "DELETE",
           headers,
         }),
@@ -707,7 +707,7 @@ describe("Section Routes", () => {
       const headers = await getAdminAuthHeader();
 
       const res = await app.fetch(
-        new Request("http://localhost/api/not-a-uuid", {
+        new Request("http://localhost/api/sections/not-a-uuid", {
           method: "DELETE",
           headers,
         }),
@@ -727,7 +727,7 @@ describe("Section Routes", () => {
       const section = await createSection(app, trip.id, "Section", 0);
 
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "DELETE",
         }),
       );
@@ -744,7 +744,7 @@ describe("Section Routes", () => {
 
       const headers = await getUserAuthHeader();
       const res = await app.fetch(
-        new Request(`http://localhost/api/${section.id}`, {
+        new Request(`http://localhost/api/sections/${section.id}`, {
           method: "DELETE",
           headers,
         }),

--- a/api/src/routes/sections.test.ts
+++ b/api/src/routes/sections.test.ts
@@ -252,6 +252,26 @@ describe("Section Routes", () => {
       expect(data.message).toContain("non-negative");
     });
 
+    it("returns 400 for missing orderIndex", async () => {
+      const app = createTestApp();
+      const trip = await createTrip({ title: "Missing Order Test" });
+      createdTripIds.push(trip.id);
+
+      const headers = await getAdminAuthHeader();
+      const res = await app.fetch(
+        new Request(`http://localhost/api/trips/${trip.id}/sections`, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Valid Title" }), // No orderIndex
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as ErrorResponse;
+      expect(data.error).toBe("Bad Request");
+      expect(data.message).toContain("required");
+    });
+
     it("returns 409 for duplicate (trip_id, order_index)", async () => {
       const app = createTestApp();
       const trip = await createTrip({ title: "Duplicate Order Test" });

--- a/api/src/routes/sections.ts
+++ b/api/src/routes/sections.ts
@@ -169,7 +169,7 @@ sections.post("/trips/:tripId/sections", requireAdmin, async (c) => {
 // =============================================================================
 // PATCH /api/sections/:id - Update a section
 // =============================================================================
-sections.patch("/:id", requireAdmin, async (c) => {
+sections.patch("/sections/:id", requireAdmin, async (c) => {
   const id = c.req.param("id");
   const body = await c.req.json<{
     title?: string;
@@ -266,7 +266,7 @@ sections.patch("/:id", requireAdmin, async (c) => {
 // =============================================================================
 // DELETE /api/sections/:id - Delete a section
 // =============================================================================
-sections.delete("/:id", requireAdmin, async (c) => {
+sections.delete("/sections/:id", requireAdmin, async (c) => {
   const id = c.req.param("id");
 
   // Validate UUID format

--- a/api/src/routes/sections.ts
+++ b/api/src/routes/sections.ts
@@ -113,11 +113,20 @@ sections.post("/trips/:tripId/sections", requireAdmin, async (c) => {
   }
 
   // Validate orderIndex
-  if (orderIndex < 0) {
+  if (orderIndex === undefined || orderIndex === null) {
     return c.json(
       {
         error: "Bad Request",
-        message: "Order index must be non-negative.",
+        message: "Order index is required.",
+      },
+      400,
+    );
+  }
+  if (typeof orderIndex !== "number" || orderIndex < 0) {
+    return c.json(
+      {
+        error: "Bad Request",
+        message: "Order index must be a non-negative number.",
       },
       400,
     );

--- a/api/src/routes/sections.ts
+++ b/api/src/routes/sections.ts
@@ -1,0 +1,160 @@
+import { Hono } from "hono";
+import { getDbClient } from "../db/client";
+import { requireAdmin } from "../middleware/auth";
+import type { AuthEnv } from "../types/auth";
+import { toSectionResponse } from "./trips";
+
+// =============================================================================
+// Database Types
+// =============================================================================
+
+interface DbSection {
+  id: string;
+  trip_id: string;
+  title: string;
+  order_index: number;
+  created_at: Date;
+  updated_at: Date;
+}
+
+// =============================================================================
+// Validation Helpers
+// =============================================================================
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_TITLE_LENGTH = 200;
+
+function isValidTitle(title: string): boolean {
+  return title.trim().length > 0 && title.length <= MAX_TITLE_LENGTH;
+}
+
+// Check if error is a unique constraint violation
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as { code: string }).code === "23505"
+  );
+}
+
+// =============================================================================
+// Routes
+// =============================================================================
+
+const sections = new Hono<AuthEnv>();
+
+// =============================================================================
+// GET /api/trips/:tripId/sections - List sections for a trip
+// =============================================================================
+sections.get("/trips/:tripId/sections", requireAdmin, async (c) => {
+  const tripId = c.req.param("tripId");
+  const db = getDbClient();
+
+  // Validate UUID format
+  if (!UUID_REGEX.test(tripId)) {
+    return c.json(
+      { error: "Bad Request", message: "Invalid trip ID format." },
+      400,
+    );
+  }
+
+  // Check if trip exists
+  const tripResults = await db<{ id: string }[]>`
+    SELECT id FROM trips WHERE id = ${tripId}
+  `;
+
+  if (tripResults.length === 0) {
+    return c.json({ error: "Not Found", message: "Trip not found" }, 404);
+  }
+
+  // Get all sections for this trip
+  const sectionResults = await db<DbSection[]>`
+    SELECT id, trip_id, title, order_index, created_at, updated_at
+    FROM sections
+    WHERE trip_id = ${tripId}
+    ORDER BY order_index ASC
+  `;
+
+  return c.json({
+    sections: sectionResults.map(toSectionResponse),
+  });
+});
+
+// =============================================================================
+// POST /api/trips/:tripId/sections - Create a section
+// =============================================================================
+sections.post("/trips/:tripId/sections", requireAdmin, async (c) => {
+  const tripId = c.req.param("tripId");
+  const body = await c.req.json<{
+    title: string;
+    orderIndex: number;
+  }>();
+
+  const { title, orderIndex } = body;
+
+  // Validate UUID format
+  if (!UUID_REGEX.test(tripId)) {
+    return c.json(
+      { error: "Bad Request", message: "Invalid trip ID format." },
+      400,
+    );
+  }
+
+  // Validate title
+  if (!isValidTitle(title)) {
+    return c.json(
+      {
+        error: "Bad Request",
+        message: `Title is required and must be ${MAX_TITLE_LENGTH} characters or less.`,
+      },
+      400,
+    );
+  }
+
+  // Validate orderIndex
+  if (orderIndex < 0) {
+    return c.json(
+      {
+        error: "Bad Request",
+        message: "Order index must be non-negative.",
+      },
+      400,
+    );
+  }
+
+  const db = getDbClient();
+
+  // Check if trip exists
+  const tripResults = await db<{ id: string }[]>`
+    SELECT id FROM trips WHERE id = ${tripId}
+  `;
+
+  if (tripResults.length === 0) {
+    return c.json({ error: "Not Found", message: "Trip not found" }, 404);
+  }
+
+  // Insert section
+  try {
+    const [section] = await db<DbSection[]>`
+      INSERT INTO sections (trip_id, title, order_index)
+      VALUES (${tripId}, ${title.trim()}, ${orderIndex})
+      RETURNING id, trip_id, title, order_index, created_at, updated_at
+    `;
+
+    return c.json(toSectionResponse(section), 201);
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return c.json(
+        {
+          error: "Conflict",
+          message: "A section with this order already exists for this trip",
+        },
+        409,
+      );
+    }
+    throw error;
+  }
+});
+
+export { sections };


### PR DESCRIPTION
## Summary
- Implements Section CRUD API endpoints for trip organization
- GET /api/trips/:tripId/sections - list sections for a trip
- POST /api/trips/:tripId/sections - create a new section
- PATCH /api/sections/:id - update section title/orderIndex
- DELETE /api/sections/:id - delete section (photos.section_id set to NULL)

## Test plan
- [x] 33 integration tests pass (all CRUD operations, validation, auth)
- [x] Type check passes
- [ ] Manual testing with curl/Postman

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)