### PR TITLE
fix(api): improve database connection resilience

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -14,8 +14,11 @@ DATABASE_SSL=false
 # For remote dev against prod DB, see api/.env.prod.example
 # Only set to false for local dev with self-signed certs (insecure!)
 # DATABASE_SSL_REJECT_UNAUTHORIZED=false
+# Connection pool settings (all timeouts in seconds)
 DATABASE_POOL_SIZE=10
-DATABASE_IDLE_TIMEOUT_MS=10000
+DATABASE_IDLE_TIMEOUT_S=30
+DATABASE_CONNECT_TIMEOUT_S=30
+DATABASE_MAX_LIFETIME_S=1800
 
 # JWT Configuration
 # Generate secret with: openssl rand -hex 32

--- a/api/.env.production.example
+++ b/api/.env.production.example
@@ -26,8 +26,12 @@ FRONTEND_URL=https://photos.joeczar.com
 #   Then use here: DATABASE_URL=postgresql://vacay:mySecretPass123@postgres:5432/vacay
 DATABASE_URL=postgresql://vacay:REPLACE_WITH_STRONG_PASSWORD@postgres:5432/vacay
 DATABASE_SSL=false
+
+# Connection pool settings (all timeouts in seconds)
 DATABASE_POOL_SIZE=10
-DATABASE_IDLE_TIMEOUT_MS=10000
+DATABASE_IDLE_TIMEOUT_S=30
+DATABASE_CONNECT_TIMEOUT_S=30
+DATABASE_MAX_LIFETIME_S=1800
 
 # =============================================================================
 # JWT Configuration

--- a/api/src/db/client.ts
+++ b/api/src/db/client.ts
@@ -27,17 +27,27 @@ const getSslConfig = () => {
   return { rejectUnauthorized };
 };
 
-const getPoolSize = () => {
-  const value = process.env.DATABASE_POOL_SIZE;
+function parsePositiveInt(
+  value: string | undefined,
+  defaultValue: number,
+): number {
   const parsed = value ? Number.parseInt(value, 10) : NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 10;
-};
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
 
-const getIdleTimeout = () => {
-  const value = process.env.DATABASE_IDLE_TIMEOUT_MS;
-  const parsed = value ? Number.parseInt(value, 10) : NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 10_000;
-};
+const getPoolSize = () => parsePositiveInt(process.env.DATABASE_POOL_SIZE, 10);
+
+// Note: postgres.js uses seconds for idle_timeout
+const getIdleTimeout = () =>
+  parsePositiveInt(process.env.DATABASE_IDLE_TIMEOUT_S, 30);
+
+// Connection attempt timeout in seconds
+const getConnectTimeout = () =>
+  parsePositiveInt(process.env.DATABASE_CONNECT_TIMEOUT_S, 30);
+
+// Max connection lifetime in seconds (recycle connections periodically)
+const getMaxLifetime = () =>
+  parsePositiveInt(process.env.DATABASE_MAX_LIFETIME_S, 1800);
 
 let client: ReturnType<typeof postgres> | null = null;
 
@@ -47,6 +57,11 @@ export const getDbClient = () => {
       ssl: getSslConfig(),
       max: getPoolSize(),
       idle_timeout: getIdleTimeout(),
+      connect_timeout: getConnectTimeout(),
+      max_lifetime: getMaxLifetime(),
+      onnotice: (notice) => {
+        console.log("[DB] Notice:", notice.message);
+      },
     });
   }
 
@@ -95,8 +110,147 @@ export const connectWithRetry = async (
 };
 
 export const closeDbClient = async () => {
+  stopConnectionHealthCheck();
   if (client) {
     await client.end();
     client = null;
   }
 };
+
+// =============================================================================
+// Connection Health Monitoring
+// =============================================================================
+
+let healthCheckInterval: Timer | null = null;
+let consecutiveHealthCheckFailures = 0;
+const MAX_CONSECUTIVE_HEALTH_FAILURES = 5;
+
+export const startConnectionHealthCheck = (intervalMs = 60_000) => {
+  if (healthCheckInterval) return;
+
+  console.log(
+    `[DB] Starting connection health check (interval: ${intervalMs / 1000}s)`,
+  );
+
+  consecutiveHealthCheckFailures = 0;
+
+  healthCheckInterval = setInterval(async () => {
+    try {
+      const start = Date.now();
+      await pingDatabase();
+      const duration = Date.now() - start;
+      console.log(`[DB] Health check OK (${duration}ms)`);
+      consecutiveHealthCheckFailures = 0; // Reset on success
+    } catch (error) {
+      consecutiveHealthCheckFailures++;
+      const message = error instanceof Error ? error.message : "Unknown error";
+      console.error(
+        `[DB] Health check FAILED (${consecutiveHealthCheckFailures}/${MAX_CONSECUTIVE_HEALTH_FAILURES}): ${message}`,
+      );
+
+      if (consecutiveHealthCheckFailures >= MAX_CONSECUTIVE_HEALTH_FAILURES) {
+        console.error(
+          "[DB] CRITICAL: Max consecutive health check failures reached - database connection may be dead",
+        );
+        // The /health/ready endpoint will return 503, alerting monitoring systems
+        // Application continues running to allow recovery when DB comes back
+      }
+    }
+  }, intervalMs);
+
+  // Allow process to exit gracefully without explicit cleanup
+  healthCheckInterval.unref();
+};
+
+export const stopConnectionHealthCheck = () => {
+  if (healthCheckInterval) {
+    clearInterval(healthCheckInterval);
+    healthCheckInterval = null;
+    consecutiveHealthCheckFailures = 0;
+    console.log("[DB] Stopped connection health check");
+  }
+};
+
+// =============================================================================
+// Query Retry Wrapper for Transient Errors
+// =============================================================================
+
+// PostgreSQL error codes for transient/recoverable errors
+const TRANSIENT_ERROR_CODES = [
+  "57P01", // admin_shutdown
+  "57P02", // crash_shutdown
+  "57P03", // cannot_connect_now
+  "08000", // connection_exception
+  "08003", // connection_does_not_exist
+  "08006", // connection_failure
+  "08001", // sqlclient_unable_to_establish_sqlconnection
+  "08004", // sqlserver_rejected_establishment_of_sqlconnection
+  "40001", // serialization_failure (retry recommended)
+  "40P01", // deadlock_detected (retry recommended)
+];
+
+// Network-level error patterns that indicate transient issues
+const TRANSIENT_ERROR_PATTERNS = [
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "Connection terminated unexpectedly",
+  "connection pool exhausted",
+];
+
+export function isTransientError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const errorObj = error as { code?: string; message?: string };
+
+  // Check PostgreSQL error codes
+  if (errorObj.code && TRANSIENT_ERROR_CODES.includes(errorObj.code)) {
+    return true;
+  }
+
+  // Check error message for network-level issues
+  if (typeof errorObj.message === "string") {
+    return TRANSIENT_ERROR_PATTERNS.some((pattern) =>
+      errorObj.message!.includes(pattern),
+    );
+  }
+
+  return false;
+}
+
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  maxRetries = 3,
+  initialDelayMs = 100,
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+
+      if (!isTransientError(error) || attempt === maxRetries) {
+        throw error;
+      }
+
+      const errorCode =
+        error && typeof error === "object" && "code" in error
+          ? (error as { code: string }).code
+          : "unknown";
+
+      console.warn(
+        `[DB] Transient error (${errorCode}), retry ${attempt}/${maxRetries}`,
+      );
+
+      // Exponential backoff: 100ms, 200ms, 400ms...
+      const delay = initialDelayMs * Math.pow(2, attempt - 1);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+
+  throw lastError;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -7,7 +7,7 @@ import { trips } from "./routes/trips";
 import { upload } from "./routes/upload";
 import { invites } from "./routes/invites";
 import { tripAccess } from "./routes/trip-access";
-import { connectWithRetry } from "./db/client";
+import { connectWithRetry, startConnectionHealthCheck } from "./db/client";
 
 const app = new Hono();
 
@@ -58,6 +58,10 @@ async function startServer() {
 
   try {
     await connectWithRetry();
+
+    // Start periodic health check (every 60 seconds)
+    startConnectionHealthCheck(60_000);
+
     console.log(`Server ready on port ${port}`);
   } catch (error) {
     console.error(


### PR DESCRIPTION
## Summary

Fixes persistent database disconnection issues by improving connection pool configuration and adding monitoring capabilities.

**Key changes:**
- **Fixed critical bug**: `idle_timeout` was set to 10,000 seconds (2.7 hours!) instead of 10 seconds due to unit mismatch with postgres.js
- **Increased idle_timeout**: From 10s to 30s to reduce connection churn under variable load
- **Added connect_timeout**: 30s default to prevent hanging connections
- **Added max_lifetime**: 30 min default to recycle connections periodically
- **Added health monitoring**: Periodic health check logs every 60s with consecutive failure tracking
- **Added retry wrapper**: `withRetry()` exported for routes that need explicit retry logic
- **Enhanced error detection**: Now catches network-level transient errors (ETIMEDOUT, ECONNRESET, etc.)

## Test plan

- [x] Run `pnpm test` - all 209 tests pass
- [x] Run `pnpm type-check` - passes
- [x] PR review toolkit - addressed critical and important issues
- [ ] Deploy to production and monitor `/health/ready` endpoint
- [ ] Watch for `[DB] Health check OK` logs indicating stable connections
- [ ] Monitor for connection-related errors in logs

## Configuration

New environment variables (all optional, sensible defaults provided):
```bash
DATABASE_IDLE_TIMEOUT_S=30      # Close idle connections after N seconds
DATABASE_CONNECT_TIMEOUT_S=30   # Connection attempt timeout
DATABASE_MAX_LIFETIME_S=1800    # Max connection lifetime (30 min)
```

**Note:** `DATABASE_IDLE_TIMEOUT_MS` renamed to `DATABASE_IDLE_TIMEOUT_S` since postgres.js uses seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)